### PR TITLE
added v0.1.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,3 @@
-#### 0.1.0 August 14 2017 ####
-First release
+#### 0.1.0 August 05 2021 ####
+- First release of Akka.Cluster.Sharding.RepairTool
+- Added detailed README instructions: https://github.com/petabridge/Akka.Cluster.Sharding.RepairTool

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,8 @@
     <Copyright>Copyright © 2015-2021 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <PackageReleaseNotes>First release</PackageReleaseNotes>
+    <PackageReleaseNotes>- First release of Akka.Cluster.Sharding.RepairTool
+- Added detailed README instructions: https://github.com/petabridge/Akka.Cluster.Sharding.RepairTool</PackageReleaseNotes>
     <PackageIconUrl>
     </PackageIconUrl>
     <PackageProjectUrl>


### PR DESCRIPTION
#### 0.1.0 August 05 2021 ####
- First release of Akka.Cluster.Sharding.RepairTool
- Added detailed README instructions: https://github.com/petabridge/Akka.Cluster.Sharding.RepairTool